### PR TITLE
correcao numero de caracteres maximo

### DIFF
--- a/tools/checkstyle.xml
+++ b/tools/checkstyle.xml
@@ -98,7 +98,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
-            <property name="max" value="120"/>
+            <property name="max" value="80"/>
         </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>


### PR DESCRIPTION
O número máximo de caracteres estava em 120, enquanto nossa convenção é de 80. Acredito que a configuração original foi perdida na criação da pasta 'tools'