### PR TITLE
Atualizacao da versao do java para 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ cache:
   - "$HOME/.m2/repository"
   - "$HOME/.sonar/cache"
 jdk:
-  - openjdk10
+  - openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     </scm>
 
     <properties>
-        <java.version>9</java.version>
+        <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Mudança da versão do java, de 9 para 11, tentando manter a compatibilidade com o spring... compatível na versão 2.3 com java 8, 11 até 14. 